### PR TITLE
Change case of English translation of the button

### DIFF
--- a/gis-vib.user.js
+++ b/gis-vib.user.js
@@ -19,7 +19,7 @@
 // ==/UserScript==
 
 const lang = {
-  en: 'View Image',
+  en: 'View image',
   ru: 'Показать в полном размере',
   ja: '画像を表示',
   he: 'הצג תמונה',


### PR DESCRIPTION
Google actually never used title case for this button, nor it does for the rest of them, so we should aim for consistency and only capitalize the first letter. You can see it on "View saved" button or on screenshots such as [this](https://petapixel.com/assets/uploads/2018/02/viewcopyright-800x435.jpg).